### PR TITLE
Replaced minipage+subcaption by subfigure

### DIFF
--- a/mmsp2016/mmsp2016.tex
+++ b/mmsp2016/mmsp2016.tex
@@ -82,25 +82,26 @@ neighboring superblock DC coefficients: left, top-left, top, and top-right.
 
 \begin{figure}
 	\centering
-	\begin{minipage}[t]{0.49\columnwidth}
+	\begin{subfigure}[t]{0.49\columnwidth}
 		\includegraphics[width=\columnwidth]{block32_L0}
-		\subcaption{Original DC coefficients before Haar DC}
-	\end{minipage}
-	\begin{minipage}[t]{0.49\columnwidth}
+		\caption{Original DC coefficients before Haar DC}
+	\end{subfigure}
+	\begin{subfigure}[t]{0.49\columnwidth}
 		\includegraphics[width=\columnwidth]{block32_L1}
-		\subcaption{DC coefficients from $4\times 4$ blocks are combined}
-	\end{minipage}
-	\begin{minipage}[t]{0.49\columnwidth}
+		\caption{DC coefficients from $4\times 4$ blocks are combined}
+	\end{subfigure}
+	\begin{subfigure}[t]{0.49\columnwidth}
 		\includegraphics[width=\columnwidth]{block32_L2}
-		\subcaption{DC coefficients from $8\times 8$ sub-blocks are combined}
-	\end{minipage}
-	\begin{minipage}[t]{0.49\columnwidth}
+		\caption{DC coefficients from $8\times 8$ sub-blocks are combined}
+	\end{subfigure}
+	\begin{subfigure}[t]{0.49\columnwidth}
 		\includegraphics[width=\columnwidth]{block32_L3}
-		\subcaption{DC coefficients from $16\times 16$ sub-blocks are combined}
-	\end{minipage}
+		\caption{DC coefficients from $16\times 16$ sub-blocks are combined}
+	\end{subfigure}
 	\caption{Example of applying Haar DC over three levels on a $32\times 32$
 		sub-block. The process is applied all the way to $64\times 64$. Remaining DC
-		coefficients are shown in red}\label{fig:haardc}
+		coefficients are shown in red}
+	\label{fig:haardc}
 \end{figure}
 
 \subsection{Multi-Symbol Entropy Coder}


### PR DESCRIPTION
Since the package subcaption is already used, it provides
Subfigure which is more flexible than minipage + subcaption see
http://mirror.its.dal.ca/ctan/macros/latex/contrib/caption/subcaption.pdf
Also more standard see
https://en.wikibooks.org/wiki/LaTeX/Floats,_Figures_and_Captions#Subfloats
