### PR TITLE
Added url package to break urls at an approriate place

### DIFF
--- a/mmsp2016/mmsp2016.tex
+++ b/mmsp2016/mmsp2016.tex
@@ -9,6 +9,7 @@
 \usepackage{units}
 \usepackage{graphicx}
 \usepackage{subcaption}
+\usepackage{url}
 \usepackage[capitalise]{cleveref}
 \crefname{equation}{}{}
 \begin{document}


### PR DESCRIPTION
It is important in multicolumn environment, where the line width is
shorten, to break long running urls so they don't go off page. This
was the case of [8]. The url package manages this without resorting
to manually fiddling with the bibtex entry.
